### PR TITLE
Solved issue #5

### DIFF
--- a/ng-message-center.js
+++ b/ng-message-center.js
@@ -32,6 +32,11 @@ angular.module('federicot.ng-message-center', [])
             var msg;
             msg = angular.extend({}, this.defaultOptions, options);
 
+            if (messages[msg.name] === undefined) {
+                console.error("Directive ngmessagecenter-messages with name '" + msg.name + "' can't be found.");
+                return;
+            }
+
             if (!msg.stack) {
                 this.clear(msg.name);
             }


### PR DESCRIPTION
#5

Now when one message is added to a message container that doesn't exist, the api throws a console error.
